### PR TITLE
Fix bug requiring user to edit InputMaps

### DIFF
--- a/navigation.gd
+++ b/navigation.gd
@@ -6,10 +6,8 @@ var path = []
 # The 'click' event is a custom input action defined in
 # Project > Project Settings > Input Map tab
 func _input(event):
-	if not event.is_action_pressed('click'):
-		return
-	_update_navigation_path($Character.position, get_local_mouse_position())
-
+	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.pressed:
+		_update_navigation_path($Character.position, get_local_mouse_position())
 
 func _update_navigation_path(start_position, end_position):
 	# get_simple_path is part of the Navigation2D class


### PR DESCRIPTION
It was required to have the user create new InputMap to get the demo working. This should not be a requirement especially since this is how it is done for 3D